### PR TITLE
Fix regex links

### DIFF
--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -332,7 +332,7 @@ class PartialMessageConverter(Converter[disnake.PartialMessage]):
     def _get_id_matches(ctx, argument):
         id_regex = re.compile(r'(?:(?P<channel_id>[0-9]{15,20})-)?(?P<message_id>[0-9]{15,20})$')
         link_regex = re.compile(
-            r'https?://(?:(ptb|canary|www)\.)?disnake(?:app)?\.com/channels/'
+            r'https?://(?:(ptb|canary|www)\.)?discord(?:app)?\.com/channels/'
             r'(?P<guild_id>[0-9]{15,20}|@me)'
             r'/(?P<channel_id>[0-9]{15,20})/(?P<message_id>[0-9]{15,20})/?$'
         )

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -660,7 +660,7 @@ def resolve_invite(invite: Union[Invite, str]) -> str:
     if isinstance(invite, Invite):
         return invite.code
     else:
-        rx = r'(?:https?\:\/\/)?disnake(?:\.gg|(?:app)?\.com\/invite)\/(.+)'
+        rx = r'(?:https?\:\/\/)?discord(?:\.gg|(?:app)?\.com\/invite)\/(.+)'
         m = re.match(rx, invite)
         if m:
             return m.group(1)
@@ -688,7 +688,7 @@ def resolve_template(code: Union[Template, str]) -> str:
     if isinstance(code, Template):
         return code.code
     else:
-        rx = r'(?:https?\:\/\/)?disnake(?:\.new|(?:app)?\.com\/template)\/(.+)'
+        rx = r'(?:https?\:\/\/)?discord(?:\.new|(?:app)?\.com\/template)\/(.+)'
         m = re.match(rx, code)
         if m:
             return m.group(1)


### PR DESCRIPTION
## Summary

Fix regex links so they point to discord.gg and not disnake.gg

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
