### PR TITLE
Add a parse_token function

### DIFF
--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -49,7 +49,7 @@ from typing import (
     TYPE_CHECKING,
 )
 import unicodedata
-from base64 import b64encode
+from base64 import b64encode, urlsafe_b64decode as b64decode
 from bisect import bisect_left
 import datetime
 import functools
@@ -73,6 +73,7 @@ else:
 
 __all__ = (
     'oauth_url',
+    'parse_token',
     'snowflake_time',
     'time_snowflake',
     'find',
@@ -315,6 +316,32 @@ def oauth_url(
         url += '&disable_guild_select=true'
     return url
 
+
+def parse_token(token: str) -> Tuple[int, datetime.datetime, bytes]:
+    """Parse a token into its parts
+    
+    Returns 
+    
+    Parameters
+    -----------
+    token: :class:`token`
+        The bot token
+    
+    Returns
+    --------
+    Tuple[:class:`int`, :class:`datetime.datetime`, :class:`bytes`]
+        the bot's id, the time when the token was generated and the hmac.
+    """
+    parts = token.split('.')
+    
+    user_id = int(b64decode(parts[0]))
+    
+    timestamp = int.from_bytes(b64decode(parts[1] + '=='), 'big')
+    created_at = datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
+    
+    hmac = b64decode(parts[2] + '==')
+    
+    return user_id, created_at, hmac
 
 def snowflake_time(id: int) -> datetime.datetime:
     """

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -324,7 +324,7 @@ def parse_token(token: str) -> Tuple[int, datetime.datetime, bytes]:
     
     Parameters
     -----------
-    token: :class:`token`
+    token: :class:`str`
         The bot token
     
     Returns


### PR DESCRIPTION
Allow the user to parse their bot token to get the user id and other data from it.

![image](https://user-images.githubusercontent.com/58166507/133888445-78d6cb2c-cafa-4991-8acf-1fd524620830.png)

Sadly there's not much use for this feature as the clientuser is created right on start during login.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
