### PR TITLE
Implement Param

### DIFF
--- a/disnake/client.py
+++ b/disnake/client.py
@@ -292,9 +292,9 @@ class Client:
         return False
 
     @property
-    def user(self) -> Optional[ClientUser]:
+    def user(self) -> ClientUser:
         """Optional[:class:`.ClientUser`]: Represents the connected client. ``None`` if not logged in."""
-        return self._connection.user
+        return self._connection.user # type: ignore
 
     @property
     def guilds(self) -> List[Guild]:

--- a/disnake/ext/commands/__init__.py
+++ b/disnake/ext/commands/__init__.py
@@ -20,3 +20,5 @@ from .converter import *
 from .cooldowns import *
 from .cog import *
 from .flags import *
+
+from .params import param, param as Param, option_enum

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -22,6 +22,7 @@ import disnake
 from disnake.app_commands import Option, OptionChoice
 from disnake.enums import OptionType, try_enum_to_int
 from . import errors
+from .converter import CONVERTER_MAPPING
 
 if TYPE_CHECKING:
     from disnake.interactions import ApplicationCommandInteraction as Interaction
@@ -170,6 +171,10 @@ class Param:
             self.type = type(self.choices[0].value)
         elif annotation in self.TYPES:
             self.type = annotation
+        elif annotation in CONVERTER_MAPPING:
+            if self.converter:
+                raise TypeError("Cannot use an implicit converter annotation and a converter argument at the same time")
+            self.converter = CONVERTER_MAPPING[annotation]().convert
         else:
             raise TypeError(f"{annotation!r} is not a valid Param annotation")
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -1,0 +1,209 @@
+"""Repsonsible for handling Params for slash commands"""
+from __future__ import annotations
+
+import inspect
+from enum import Enum, EnumMeta
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Type, TypeVar, Union, get_origin, get_type_hints
+
+import disnake
+from disnake.app_commands import Option, OptionChoice
+from disnake.enums import OptionType, try_enum_to_int
+
+if TYPE_CHECKING:
+    from disnake.interactions import ApplicationCommandInteraction as Interaction
+
+TChoice = TypeVar("TChoice", str, int)
+
+__all__ = (
+    "extract_params",
+    "param",
+    "option_enum",
+)
+
+
+class Param:
+    """
+    Parameters
+    ----------
+    default: Union[:class:`str`, Callable[[:class:`ApplicationCommandInteraction`, Any], Any]]
+        default value or a default value factory
+    name: :class:`str`
+        option's name, the parameter name by default
+    description: :class:`str`
+        option's description
+    converter: Callable[[:class:`ApplicationCommandInteraction`, Any], Any]
+        the option's converter, takes in an interaction and the argument
+    choices: List[:class:`OptionChoice`]
+    type: :class:`type`
+    """
+
+    TYPES: Dict[type, int] = {
+        str: 3,
+        int: 4,
+        bool: 5,
+        disnake.abc.User: 6,
+        disnake.User: 6,
+        disnake.Member: 6,
+        disnake.abc.GuildChannel: 7,
+        disnake.TextChannel: 7,
+        disnake.VoiceChannel: 7,
+        disnake.CategoryChannel: 7,
+        disnake.StageChannel: 7,
+        disnake.StoreChannel: 7,
+        disnake.Role: 8,
+        Union[disnake.Member, disnake.Role]: 9,
+        disnake.abc.Snowflake: 9,
+        float: 10,
+    }
+
+    def __init__(
+        self,
+        default: Any = ...,
+        *,
+        name: str = '',
+        description: str = None,
+        converter: Callable[[Interaction, Any], Any] = None,
+        choices: List[OptionChoice] = None,
+        type: type = str,
+    ) -> None:
+        self.default = default
+        self.name = name
+        self.param_name = name
+        self.description = description or "\u200b"
+        self.converter = converter
+
+        self.choices = choices or []
+        self.type = type
+
+    @property
+    def required(self):
+        return self.default is ...
+
+    @property
+    def discord_type(self) -> OptionType:
+        return OptionType(self.TYPES.get(self.type, OptionType.string.value))
+
+    @discord_type.setter
+    def discord_type(self, discord_type: OptionType) -> None:
+        value = try_enum_to_int(discord_type)
+        for t, v in self.TYPES.items():
+            if value == v:
+                self.type = t
+                return
+
+        raise TypeError(f"Type {discord_type} is not a valid Param type")
+
+    def __repr__(self):
+        return f"<Param default={self.default!r} name={self.name!r} description={self.description!r}>"
+
+    def get_default(self, inter: Interaction) -> Any:
+        """Gets the default for an interaction"""
+        if callable(self.default):
+            return self.default(inter)
+        
+        return self.default
+
+    def parse_annotation(self, annotation: Any) -> None:
+        if annotation is inspect.Parameter.empty or annotation is Any:
+            pass
+        elif isinstance(annotation, EnumMeta):
+            self.choices = [OptionChoice(name, value) for name, value in annotation.__members__.items()]  # type: ignore
+            self.type = type(self.choices[0].value)
+        elif get_origin(annotation) is Literal:
+            self.choices = [OptionChoice(str(i), i) for i in annotation.__args__]
+            self.type = type(self.choices[0].value)
+        elif annotation in self.TYPES:
+            self.type = annotation
+        else:
+            raise TypeError(f"{annotation!r} is not a valid Param annotation")
+
+    def parse_parameter(self, param: inspect.Parameter) -> None:
+        self.name = self.name or param.name.replace("_", "-")
+        self.param_name = param.name
+
+    def to_option(self) -> Option:
+        if self.name == '':
+            raise TypeError("Param must be parsed first")
+
+        return Option(
+            name=self.name,
+            description=self.description,
+            type=self.discord_type,
+            required=self.required,
+            choices=self.choices,
+        )
+
+
+def extract_params(func: Callable, cog: Any = None) -> List[Param]:
+    """Extract params from a function signature"""
+    sig = inspect.signature(func)
+    parameters = list(sig.parameters.values())
+    if cog is None:
+        # hacky I suppose
+        cog = parameters[0].name == 'self'
+    parameters = parameters[2:] if cog else parameters[1:]
+    type_hints = get_type_hints(func)
+
+    params = []
+    for parameter in parameters:
+        if parameter.kind in [inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD]:
+            continue
+        param = parameter.default
+        if not isinstance(param, Param):
+            param = Param(param if param is not parameter.empty else ...)
+
+        param.parse_parameter(parameter)
+        param.parse_annotation(type_hints.get(parameter.name, Any))
+        params.append(param)
+
+    return params
+
+
+def create_connector(params: List[Param]) -> Dict[str, Any]:
+    """Create a connector for each param"""
+    return {
+        param.name: param.param_name
+        for param in params
+        if param.name != param.param_name
+    }
+
+
+def resolve_param_kwargs(func: Callable, inter: Interaction, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolves a call with kwargs and transforms into normal kwargs
+    
+    Depends on the fact that optionparams already contain all info.
+    """
+    sig = inspect.signature(func)
+
+    for parameter in sig.parameters.values():
+        if parameter.kind in [inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD]:
+            continue
+        param = parameter.default
+        if not isinstance(param, Param):
+            continue
+
+        kwargs.setdefault(param.param_name, param.get_default(inter))
+        # TODO: Converters
+
+    return kwargs
+
+def param(
+    default: Any = ...,
+    *,
+    name: str = '',
+    desc: str = None,
+    description: str = None,
+    conv: Callable[[Interaction, Any], Any] = None,
+    converter: Callable[[Interaction, Any], Any] = None,
+    choices: List[OptionChoice] = None,
+) -> Any:
+    return Param(default, name=name, description=desc or description, converter=conv or converter, choices=choices)
+
+
+def option_enum(choices: Union[Dict[str, TChoice], List[TChoice]], **kwargs: TChoice) -> Type[TChoice]:
+    if isinstance(choices, list):
+        choices = {str(i): i for i in choices}
+
+    choices = choices or kwargs
+    first, *_ = choices.values()
+    return Enum("", choices, type=type(first))

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Dict, List, Tuple, Union, TYPE_CHECKING, Callable
+from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING, Callable
 
 from .base_core import InvokableApplicationCommand, _get_overridden_method
 from .errors import *
@@ -107,7 +107,7 @@ class SubCommand(InvokableApplicationCommand):
         self.qualified_name = ''
     
     async def invoke(self, inter: ApplicationCommandInteraction, *args, **kwargs) -> None:
-        kwargs = resolve_param_kwargs(self.callback, inter, kwargs)
+        kwargs = await resolve_param_kwargs(self.callback, inter, kwargs)
         return await super().invoke(inter, *args, **kwargs)
 
 
@@ -129,7 +129,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         self.connectors: Dict[str, str] = connectors or {}
         self.children: Dict[str, Union[SubCommand, SubCommandGroup]] = {}
         self.auto_sync: bool = auto_sync
-        self.guild_ids: List[int] = guild_ids or []
+        self.guild_ids: Optional[List[int]] = guild_ids
 
         if not options:
             params = extract_params(func, self.cog)
@@ -268,7 +268,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
                 await self(inter)
                 await self.invoke_children(inter)
             else:
-                kwargs = resolve_param_kwargs(self.callback, inter, inter.options or {})
+                kwargs = await resolve_param_kwargs(self.callback, inter, inter.options or {})
                 await self(inter, **kwargs)
         except CommandError:
             inter.command_failed = True

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Tuple, Union, TYPE_CHECKING, Callable
 
 from .base_core import InvokableApplicationCommand, _get_overridden_method
 from .errors import *
+from .params import extract_params, create_connector, resolve_param_kwargs
 
 from disnake.app_commands import SlashCommand, Option
 from disnake.enums import OptionType
@@ -40,7 +41,7 @@ class SubCommandGroup(InvokableApplicationCommand):
             type=OptionType.sub_command_group,
             options=[]
         )
-        self.qualified_name: str = None
+        self.qualified_name: str = ''
 
     def sub_command(
         self,
@@ -90,14 +91,24 @@ class SubCommand(InvokableApplicationCommand):
         **kwargs
     ):
         super().__init__(func, name=name, **kwargs)
-        self.connectors: Dict[str, str] = connectors
+        self.connectors: Dict[str, str] = connectors or {}
+        
+        if not options:
+            params = extract_params(func, self.cog)
+            options = [param.to_option() for param in params]
+            self.connectors.update(create_connector(params))
+        
         self.option = Option(
             name=self.name,
             description=description or '-',
             type=OptionType.sub_command,
             options=options
         )
-        self.qualified_name = None
+        self.qualified_name = ''
+    
+    async def invoke(self, inter: ApplicationCommandInteraction, *args, **kwargs) -> None:
+        kwargs = resolve_param_kwargs(self.callback, inter, kwargs)
+        return await super().invoke(inter, *args, **kwargs)
 
 
 class InvokableSlashCommand(InvokableApplicationCommand):
@@ -115,10 +126,16 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         **kwargs
     ):
         super().__init__(func, name=name, **kwargs)
-        self.connectors: Dict[str, str] = connectors
+        self.connectors: Dict[str, str] = connectors or {}
         self.children: Dict[str, Union[SubCommand, SubCommandGroup]] = {}
         self.auto_sync: bool = auto_sync
-        self.guild_ids: List[int] = guild_ids
+        self.guild_ids: List[int] = guild_ids or []
+
+        if not options:
+            params = extract_params(func, self.cog)
+            options = [param.to_option() for param in params]
+            self.connectors.update(create_connector(params))
+        
         self.body = SlashCommand(
             name=self.name,
             description=description or '-',
@@ -211,7 +228,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
                 if local is not None:
                     await local(inter, error)
         finally:
-            inter.bot.dispatch('slash_command_error', inter, error)
+            inter.bot.dispatch('slash_command_error', inter, error) # type: ignore
 
     async def invoke_children(self, inter: ApplicationCommandInteraction):
         chain, kwargs = options_as_route(inter.options)
@@ -224,19 +241,22 @@ class InvokableSlashCommand(InvokableApplicationCommand):
             subcmd = self.children.get(chain[0])
         elif len(chain) == 2:
             group = self.children.get(chain[0])
+            assert isinstance(group, SubCommandGroup)
             subcmd = group.children.get(chain[1]) if group is not None else None
+        else:
+            raise ValueError("Chain too long")
 
         if group is not None:
             try:
                 await group.invoke(inter)
-            except Exception as exc:
+            except CommandError as exc:
                 await group._call_local_error_handler(inter, exc)
                 raise
         
         if subcmd is not None:
             try:
                 await subcmd.invoke(inter, **kwargs)
-            except Exception as exc:
+            except CommandError as exc:
                 await subcmd._call_local_error_handler(inter, exc)
                 raise
 
@@ -248,7 +268,8 @@ class InvokableSlashCommand(InvokableApplicationCommand):
                 await self(inter)
                 await self.invoke_children(inter)
             else:
-                await self(inter, **inter.options)
+                kwargs = resolve_param_kwargs(self.callback, inter, inter.options or {})
+                await self(inter, **kwargs)
         except CommandError:
             inter.command_failed = True
             raise
@@ -260,7 +281,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
             raise CommandInvokeError(exc) from exc
         finally:
             if self._max_concurrency is not None:
-                await self._max_concurrency.release(inter)
+                await self._max_concurrency.release(inter) # type: ignore
 
             await self.call_after_hooks(inter)
 

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -75,7 +75,7 @@ class ApplicationCommandInteraction(Interaction):
         return self.data.target
     
     @property
-    def options(self) -> Optional[Dict[str, Any]]:
+    def options(self) -> Dict[str, Any]:
         return self.data.options
 
 

--- a/examples/slash_commands/option_choice.py
+++ b/examples/slash_commands/option_choice.py
@@ -7,7 +7,7 @@ intents = Intents.all()
 # In production please choose the intents coresponding to your use case.
 
 # We create the instance of the bot.
-bot = commands.Bot(intents=intents)
+bot = commands.Bot('!', intents=intents)
 
 # For this example we're going to make a rock-paper-scissors game
 # which will use OptionChoice as the input.

--- a/examples/slash_commands/param.py
+++ b/examples/slash_commands/param.py
@@ -1,0 +1,105 @@
+import disnake
+from disnake.ext import commands
+from disnake.ext.commands import Param
+
+bot = commands.Bot("!")
+
+# disnake can use a fastapi-like option syntax.
+# That means instead of using the options keyword you will be
+# setting the default of your parameters.
+# It should allow you to create more readable commands and make the more complicated
+# features easier to use.
+# Not only that but using Param even adds support for a ton of other features.
+
+# We create a new command with two options: required (a requistring) and optional (an integer).
+# Param takes care of parsing the annotation and adding a description for it.
+# If you want to provide a default value and make the option optional simply provide it as the first argument.
+# "description" may be shortened to "desc" if you so choose.
+@bot.slash_command()
+async def simple(
+    inter: disnake.ApplicationCommandInteraction,
+    required: str = Param(description="The required argument"),
+    optional: int = Param(0, desc="The optional argument"),
+):
+    ...
+
+
+# To make an option required don't provide a default or set it to "..."
+# Callable defaults are allowed too, in this case it defaults to the author.
+@bot.slash_command()
+async def defaults(
+    inter: disnake.ApplicationCommandInteraction,
+    required: str = Param(desc="a"),
+    also_required: str = Param(..., desc="b"),
+    member: str = Param(lambda inter: inter.author),
+):
+    ...
+
+
+# Names are automatically discerned from the parameter name ("_" are changed to "-")
+# However you may want to provide your own name in some cases.
+@bot.slash_command()
+async def names(
+    inter: disnake.ApplicationCommandInteraction, 
+    class_: str = Param(name="class", desc="Your class")
+):
+    ...
+
+
+# Not all types are currently supported by discord, you may use converters in these cases.
+# Both old command converters using annotations and converters using functions are supported.
+# However converters which are not consistent with the actual type are not allowed.
+# That means no Converter classes and no fuckery like clean_content may be used in an annotation.
+@bot.slash_command()
+async def converters(
+    inter: disnake.ApplicationCommandInteraction,
+    emoji: disnake.Emoji = Param(desc="An emoji"),
+    content: str = Param(desc="Clean content", converter=lambda inter, arg: arg.replace("@", "\\@")),
+):
+    ...
+
+
+# Enumeration (choices) is allowed using enum.Enum, commands.option_enum or Literal
+# The user will see the enum member name or the dict key and the bot will receive the value.
+from enum import Enum
+from typing import Literal
+
+
+class Language(int, Enum):
+    en = 1
+    fr = 2
+    de = 3
+    es = 4
+
+
+Color = commands.option_enum(["Red", "Green", "Blue", "Yellow"])
+Gender = commands.option_enum({"Male": "M", "Female": "F", "Other": "O", "Prefer Not To Say": "P"})
+
+
+@bot.slash_command()
+async def enumeration(
+    inter: disnake.ApplicationCommandInteraction,
+    langs: Language = Param(desc="Your language"),
+    color: Color = Param(desc="Your favorite color"),
+    gender: Gender = Param(desc="Your gender"),
+    mode: Literal[1, 2, 3] = Param(desc="Mode of your choosing"),
+):
+    ...
+
+
+# Specific types may be required of the user.
+# If they provide the wrong one a BadArgument exception is raised.
+@bot.slash_command()
+async def verify(
+    inter: disnake.ApplicationCommandInteraction, 
+    channel: disnake.TextChannel = Param(desc="a TEXT channel")
+):
+    ...
+
+
+@verify.error
+async def on_verify_errror(inter, exception):
+    if isinstance(exception, commands.ChannelNotFound):
+        await inter.response.send_message("The channel must be a text channel")
+        return
+    ...


### PR DESCRIPTION
## Summary

An implementation of `Param` - a fastapi-like way to describe options of a slash command using descriptor-like defaults. See dislash.py for a beta implementation.

## Todo

- [x] Async Callable defaults
- [x] Enumerators for choices
- [x] Converters
    - [x] As an argument
    - [x] As an annotation (https://github.com/EQUENOS/disnake/issues/21)
- [x] Conversion/Validation for channel types and user/member
- [ ] Use `*args` and `**kwargs` somehow?

## Showcase
(and also my tests)
```py
from pprint import pformat, pprint
from typing import Literal

import disnake
from disnake.ext import commands

bot = commands.Bot("test!", test_guilds=[570841314200125460])
Foo = commands.option_enum({"My Foo": "foo", "Your bar": "bar", "Their baz": "baz"})


@bot.slash_command(guild_ids=[570841314200125460])
async def command(
    inter: disnake.ApplicationCommandInteraction,
    required: str = commands.Param(description="first required"),
    required_: int = commands.Param(..., desc="second required"),
    member: disnake.Member = commands.Param(lambda inter: inter.author, desc="defaults to the author"),
    channel: disnake.TextChannel = commands.Param(None, desc="raises error when not a text channel specifically"),
    converted: float = commands.Param(0, conv=lambda inter, arg: arg ** 2, desc="Explicit conversion"),
    emoji: disnake.Emoji = commands.Param(None, desc="Implicit conversion"),
    enumerated: Foo = commands.Param("foo", desc="Can only pick from members of Foo"),
    lit_enumerated: Literal[1, 2, 3] = commands.Param(1, desc="Literals are allowed too"),
):
    await inter.response.send_message("```" + pformat(locals()) + "```")


class Cog(commands.Cog):
    @commands.slash_command(guild_ids=[570841314200125460])
    async def parent(self, inter: disnake.ApplicationCommandInteraction):
        pass

    @parent.sub_command()
    async def subcommand(
        self,
        inter: disnake.ApplicationCommandInteraction,
        param: str = commands.Param(lambda inter: inter.author.name, desc="Random param"),
    ):
        await inter.response.send_message(param)


bot.add_cog(Cog())
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
