### PR TITLE
Properly raise ConversionError for Param

### DIFF
--- a/disnake/ext/commands/errors.py
+++ b/disnake/ext/commands/errors.py
@@ -130,8 +130,8 @@ class ConversionError(CommandError):
         The original exception that was raised. You can also get this via
         the ``__cause__`` attribute.
     """
-    def __init__(self, converter: Converter, original: Exception) -> None:
-        self.converter: Converter = converter
+    def __init__(self, converter: Any, original: Exception) -> None:
+        self.converter: Any = converter
         self.original: Exception = original
 
 class UserInputError(CommandError):

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -154,11 +154,14 @@ class Param:
         if self.converter is None:
             return await self.verify_type(inter, argument)
 
-        argument = self.converter(inter, argument)
-        if inspect.isawaitable(argument):
-            return await argument
+        try:
+            argument = self.converter(inter, argument)
+            if inspect.isawaitable(argument):
+                return await argument
 
-        return argument
+            return argument
+        except Exception as e:
+            raise errors.ConversionError(self.converter, e) from e
 
     def parse_annotation(self, annotation: Any) -> None:
         if self.converter is not None:


### PR DESCRIPTION
## Summary

Does `ConversionError` really use to require a fucking Converter class? Man what the hell was danny thinking.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
