### PR TITLE
Fix discord icon on docs template

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -60,7 +60,7 @@
       <nav>
         <a href="{{ pathto(master_doc)|e }}" class="main-heading">disnake</a>
         <a href="https://github.com/EQUENOS/disnake" title="GitHub"><span class="material-icons custom-icons">github</span></a>
-        <a href="{{ discord_invite }}" title="{{ _('Discord') }}"><span class="material-icons custom-icons">disnake</span></a>
+        <a href="{{ discord_invite }}" title="{{ _('Discord') }}"><span class="material-icons custom-icons">discord</span></a>
         <a href="{{ pathto('faq') }}" title="FAQ"><span class="material-icons">help_center</span></a>
         {#- If we have more links we can put them here #}
         <a onclick="mobileSearch.open();" title="{{ _('Search') }}" id="open-search" class="mobile-only"><span class="material-icons">search</span></a>


### PR DESCRIPTION
## Summary

A small fix to the icons on the documentation's header. Mass changing "discord" to "disnake" caused the icon to break:
![image](https://user-images.githubusercontent.com/6181929/135010232-e6fc3e2c-4e8e-41a5-98d7-798445dd4dd0.png)
With this fix it should now look like this:
![image](https://user-images.githubusercontent.com/6181929/135010273-a7c6f9e3-cea5-49ac-bfbf-c50943064b9d.png)

I have not actually tested this since its too much effort for such a small change, but feel free to test if need be 😃.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
