### PR TITLE
Add support for fetching individual thread members

### DIFF
--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1104,6 +1104,17 @@ class HTTPClient:
         route = Route("GET", "/guilds/{guild_id}/threads/active", guild_id=guild_id)
         return self.request(route)
 
+    def get_thread_member(
+        self, channel_id: Snowflake, user_id: Snowflake
+    ) -> Response[threads.ThreadMember]:
+        route = Route(
+            "GET",
+            "/channels/{channel_id}/thread-members/{user_id}",
+            channel_id=channel_id,
+            user_id=user_id,
+        )
+        return self.request(route)
+
     def get_thread_members(self, channel_id: Snowflake) -> Response[List[threads.ThreadMember]]:
         route = Route("GET", "/channels/{channel_id}/thread-members", channel_id=channel_id)
         return self.request(route)

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -674,6 +674,31 @@ class Thread(Messageable, Hashable):
         """
         await self._state.http.remove_user_from_thread(self.id, user.id)
 
+    async def fetch_member(self, member_id: int, /) -> ThreadMember:
+        """|coro|
+
+        Retrieve a single :class:`ThreadMember` from this thread.
+
+        Parameters
+        -----------
+        member_id: :class:`int`
+            The ID of the member to fetch.
+
+        Raises
+        -------
+        NotFound
+            The specified member was not found.
+        HTTPException
+            Retrieving the member failed.
+
+        Returns
+        --------
+        :class:`ThreadMember`
+            The thread member asked for.
+        """
+        member_data = await self._state.http.get_thread_member(self.id, member_id)
+        return ThreadMember(parent=self, data=member_data)
+
     async def fetch_members(self) -> List[ThreadMember]:
         """|coro|
 


### PR DESCRIPTION
## Summary

Discord recently added support for fetching individual thread members,
which does not require the members intent.

Docs PR:
    https://github.com/discord/discord-api-docs/pull/3998

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
