### PR TITLE
Add support for boost progress bar

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -228,6 +228,8 @@ class Guild(Hashable):
         - ``VIP_REGIONS``: Guild has VIP voice regions.
         - ``WELCOME_SCREEN_ENABLED``: Guild has enabled the welcome screen.
 
+    premium_progress_bar_enabled: :class:`bool`
+        Whether the server boost progress bar is enabled.
     premium_tier: :class:`int`
         The premium tier for this guild. Corresponds to "Nitro Server" in the official UI.
         The number goes from 0 to 3 inclusive.
@@ -261,6 +263,7 @@ class Guild(Hashable):
         "max_presences",
         "max_members",
         "max_video_channel_users",
+        "premium_progress_bar_enabled",
         "premium_tier",
         "premium_subscription_count",
         "preferred_locale",
@@ -491,6 +494,7 @@ class Guild(Hashable):
             guild, "public_updates_channel_id"
         )
         self.nsfw_level: NSFWLevel = try_enum(NSFWLevel, guild.get("nsfw_level", 0))
+        self.premium_progress_bar_enabled: bool = guild.get("premium_progress_bar_enabled", False)
 
         self._stage_instances: Dict[int, StageInstance] = {}
         for s in guild.get("stage_instances", []):

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1437,6 +1437,7 @@ class Guild(Hashable):
         preferred_locale: str = MISSING,
         rules_channel: Optional[TextChannel] = MISSING,
         public_updates_channel: Optional[TextChannel] = MISSING,
+        premium_progress_bar_enabled: bool = MISSING,
     ) -> Guild:
         r"""|coro|
 
@@ -1517,6 +1518,8 @@ class Guild(Hashable):
             public updates channel.
         reason: Optional[:class:`str`]
             The reason for editing this guild. Shows up on the audit log.
+        premium_progress_bar_enabled: :class:`bool`
+            Whether the server boost progress bar is enabled.
 
         Raises
         -------
@@ -1649,6 +1652,9 @@ class Guild(Hashable):
                     )
 
             fields["features"] = features
+
+        if premium_progress_bar_enabled is not MISSING:
+            fields["premium_progress_bar_enabled"] = premium_progress_bar_enabled
 
         data = await http.edit_guild(self.id, reason=reason, **fields)
         return Guild(data=data, state=self._state)

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1212,6 +1212,7 @@ class HTTPClient:
             "rules_channel_id",
             "public_updates_channel_id",
             "preferred_locale",
+            "premium_progress_bar_enabled",
         )
 
         payload = {k: v for k, v in fields.items() if k in valid_keys}

--- a/disnake/types/audit_log.py
+++ b/disnake/types/audit_log.py
@@ -146,6 +146,7 @@ class _AuditLogChange_Bool(TypedDict):
         "available",
         "archived",
         "locked",
+        "premium_progress_bar_enabled",
     ]
     new_value: bool
     old_value: bool

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -139,6 +139,7 @@ class Guild(_BaseGuildPreview, _GuildOptional):
     rules_channel_id: Optional[Snowflake]
     vanity_url_code: Optional[str]
     banner: Optional[str]
+    premium_progress_bar_enabled: bool
     premium_tier: PremiumTier
     preferred_locale: str
     public_updates_channel_id: Optional[Snowflake]


### PR DESCRIPTION
## Summary

While still in experiment, Discord is adding a feature to allow a server to display a progress bar for how many boosts are needed to get to the next level.

We shouldn't merge this quite yet, as it's not fully testable yet.

### Todo
- [ ] Test updating a guild's `premium_progress_bar_enabled` flag once experiment ends
- [ ] Test audit log

## Checklist

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
