### PR TITLE
Add a file argument to embed.set_image

### DIFF
--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -437,11 +437,11 @@ class Embed:
             The file to use as the image.
         """
         if file:
-            self._files.append(file)
-            url = url or f"attachment://{file.filename}"
-            if not url:
+            if url:
+                raise TypeError("Cannot use both a url and a file at the same time")
+            if file.filename is None:
                 raise TypeError("File doesn't have a filename")
-            self._image = {"url": str(url)}
+            self._image = {"url": f"attachment://{file.filename}"}
         elif url is EmptyEmbed:
             try:
                 del self._image
@@ -486,11 +486,11 @@ class Embed:
             The file to use as the image.
         """
         if file:
-            self._files.append(file)
-            url = url or f"attachment://{file.filename}"
-            if not url:
+            if url:
+                raise TypeError("Cannot use both a url and a file at the same time")
+            if file.filename is None:
                 raise TypeError("File doesn't have a filename")
-            self._thumbnail = {"url": str(url)}
+            self._image = {"url": f"attachment://{file.filename}"}
         elif url is EmptyEmbed:
             try:
                 del self._thumbnail

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -25,8 +25,22 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Dict, Final, List, Mapping, Protocol, TYPE_CHECKING, Type, TypeVar, Union
+import warnings
+from typing import (
+    Any,
+    Dict,
+    Final,
+    List,
+    Mapping,
+    Protocol,
+    TYPE_CHECKING,
+    Type,
+    TypeVar,
+    Union,
+)
 
+from .file import File
+from .utils import MISSING
 from . import utils
 from .colour import Colour
 
@@ -168,6 +182,7 @@ class Embed:
         "_author",
         "_fields",
         "description",
+        "_files",
     )
 
     Empty: Final = EmptyEmbed
@@ -201,6 +216,8 @@ class Embed:
 
         if timestamp:
             self.timestamp = timestamp
+
+        self._files: List[File] = []
 
     @classmethod
     def from_dict(cls: Type[E], data: Mapping[str, Any]) -> E:
@@ -261,7 +278,9 @@ class Embed:
 
     def copy(self: E) -> E:
         """Returns a shallow copy of the embed."""
-        return self.__class__.from_dict(self.to_dict())
+        embed = self.__class__.from_dict(self.to_dict())
+        embed._files = self._files  # TODO: Maybe copy these too?
+        return embed
 
     def __len__(self) -> int:
         total = len(self.title) + len(self.description)
@@ -401,7 +420,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, "_image", {}))  # type: ignore
 
-    def set_image(self: E, url: MaybeEmpty[Any]) -> E:
+    def set_image(self: E, url: MaybeEmpty[Any] = MISSING, *, file: File = MISSING) -> E:
         """Sets the image for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -414,17 +433,24 @@ class Embed:
         -----------
         url: :class:`str`
             The source URL for the image. Only HTTP(S) is supported.
+        file: :class:`File`
+            The file to use as the image.
         """
-
-        if url is EmptyEmbed:
+        if file:
+            self._files.append(file)
+            url = url or f"attachment://{file.filename}"
+            if not url:
+                raise TypeError("File doesn't have a filename")
+            self._image = {"url": str(url)}
+        elif url is EmptyEmbed:
             try:
                 del self._image
             except AttributeError:
                 pass
+        elif url is MISSING:
+            raise TypeError("Neither a url nor a file have been provided")
         else:
-            self._image = {
-                "url": str(url),
-            }
+            self._image = {"url": str(url)}
 
         return self
 
@@ -443,7 +469,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, "_thumbnail", {}))  # type: ignore
 
-    def set_thumbnail(self: E, url: MaybeEmpty[Any]) -> E:
+    def set_thumbnail(self: E, url: MaybeEmpty[Any] = MISSING, *, file: File = MISSING) -> E:
         """Sets the thumbnail for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -456,17 +482,24 @@ class Embed:
         -----------
         url: :class:`str`
             The source URL for the thumbnail. Only HTTP(S) is supported.
+        file: :class:`File`
+            The file to use as the image.
         """
-
-        if url is EmptyEmbed:
+        if file:
+            self._files.append(file)
+            url = url or f"attachment://{file.filename}"
+            if not url:
+                raise TypeError("File doesn't have a filename")
+            self._thumbnail = {"url": str(url)}
+        elif url is EmptyEmbed:
             try:
                 del self._thumbnail
             except AttributeError:
                 pass
+        elif url is MISSING:
+            raise TypeError("Neither a url nor a file have been provided")
         else:
-            self._thumbnail = {
-                "url": str(url),
-            }
+            self._thumbnail = {"url": str(url)}
 
         return self
 
@@ -696,7 +729,7 @@ class Embed:
         result = {
             key[1:]: getattr(self, key)
             for key in self.__slots__
-            if key[0] == '_' and hasattr(self, key)
+            if key[0] == '_' and hasattr(self, key) and key != "_files"
         }
         # fmt: on
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -665,6 +665,12 @@ class InteractionResponse:
         if embed is not MISSING and embeds is not MISSING:
             raise TypeError("cannot mix embed and embeds keyword arguments")
 
+        if file is not MISSING and files is not MISSING:
+            raise TypeError("cannot mix file and files keyword arguments")
+
+        if file is not MISSING:
+            files = [file]
+
         if embed is not MISSING:
             embeds = [embed]
 
@@ -672,12 +678,10 @@ class InteractionResponse:
             if len(embeds) > 10:
                 raise ValueError("embeds cannot exceed maximum of 10 elements")
             payload["embeds"] = [e.to_dict() for e in embeds]
-
-        if file is not MISSING and files is not MISSING:
-            raise TypeError("cannot mix file and files keyword arguments")
-
-        if file is not MISSING:
-            files = [file]
+            for embed in embeds:
+                if embed._files:
+                    files = files or []
+                    files += embed._files
 
         if files is not MISSING and len(files) > 10:
             raise ValueError("files cannot exceed maximum of 10 elements")
@@ -795,6 +799,11 @@ class InteractionResponse:
             embeds = [] if embed is None else [embed]
         if embeds is not MISSING:
             payload["embeds"] = [e.to_dict() for e in embeds]
+            for embed in embeds:
+                if embed._files:
+                    raise NotImplementedError(
+                        "Embed images in edit interaction responses are not supported"
+                    )
 
         previous_mentions: Optional[AllowedMentions] = getattr(
             self._parent._state, "allowed_mentions", None

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -149,11 +149,18 @@ async def _edit_handler(
             payload["content"] = str(content)
         else:
             payload["content"] = None
+    
+    if file is not MISSING:
+        files = [file]
 
     if embed is not MISSING:
         embeds = [embed] if embed else []
     if embeds is not MISSING:
         payload["embeds"] = [e.to_dict() for e in embeds]
+        for embed in embeds:
+            if embed._files:
+                files = files or []
+                files += embed._files
 
     if suppress is not MISSING:
         flags = MessageFlags._from_value(default_flags)
@@ -181,9 +188,6 @@ async def _edit_handler(
             payload["components"] = view.to_components()
         else:
             payload["components"] = []
-
-    if file is not MISSING:
-        files = [file]
 
     data = await msg._state.http.edit_message(msg.channel.id, msg.id, **payload, files=files)
     message = Message(state=msg._state, channel=msg.channel, data=data)

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -486,30 +486,25 @@ def handle_message_parameters(
     if embeds is not MISSING and embed is not MISSING:
         raise TypeError("Cannot mix embed and embeds keyword arguments.")
 
+    if file is not MISSING:
+        files = [file]
+
     payload = {}
+    if embed is not MISSING:
+        payload["embeds"] = [] if embed is None else [embed.to_dict()]
     if embeds is not MISSING:
         if len(embeds) > 10:
             raise InvalidArgument("embeds has a maximum of 10 elements.")
         payload["embeds"] = [e.to_dict() for e in embeds]
-
-    if embed is not MISSING:
-        if embed is None:
-            payload["embeds"] = []
-        else:
-            payload["embeds"] = [embed.to_dict()]
+        for embed in embeds:
+            if embed._files:
+                files = files or []
+                files += embed._files
 
     if content is not MISSING:
-        if content is not None:
-            payload["content"] = str(content)
-        else:
-            payload["content"] = None
-
+        payload["content"] = str(content) if content is not None else None
     if view is not MISSING:
-        if view is not None:
-            payload["components"] = view.to_components()
-        else:
-            payload["components"] = []
-
+        payload["components"] = view.to_components() if view is not None else []
     payload["tts"] = tts
     if avatar_url:
         payload["avatar_url"] = str(avatar_url)
@@ -529,8 +524,6 @@ def handle_message_parameters(
         payload["allowed_mentions"] = previous_allowed_mentions.to_dict()
 
     multipart = []
-    if file is not MISSING:
-        files = [file]
 
     if files:
         multipart = to_multipart(payload, files)


### PR DESCRIPTION
## Summary

Instead of forcing users to use embeds with `attachment://file.png` and attaching the files themselves, it should be abstracted behind a simple kwarg.

## Checklist

- [x] If code changes were made then they have been (partially) tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

##### PS:
All of this stuff should seriously be handled in just a single function. Why do we have like 5 implementations of the same thing?