### PR TITLE
Adjust docstrings, add support for `files` and `attachments` parameters to more methods

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1280,11 +1280,22 @@ class Messageable:
         tts: :class:`bool`
             Indicates if the message should be sent using text-to-speech.
         embed: :class:`~disnake.Embed`
-            The rich embed for the content.
+            The rich embed for the content to send. This cannot be mixed with
+            ``embeds`` parameter.
+        embeds: List[:class:`~disnake.Embed`]
+            A list of embeds to send with the content. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
+
+            .. versionadded:: 2.0
         file: :class:`~disnake.File`
-            The file to upload.
+            The file to upload. This cannot be mixed with ``files`` parameter.
         files: List[:class:`~disnake.File`]
-            A list of files to upload. Must be a maximum of 10.
+            A list of files to send with the content. Must be a maximum of 10.
+            This cannot be mixed with the ``file`` parameter.
+        stickers: Sequence[Union[:class:`~disnake.GuildSticker`, :class:`~disnake.StickerItem`]]
+            A list of stickers to upload. Must be a maximum of 3.
+
+            .. versionadded:: 2.0
         nonce: :class:`int`
             The nonce to use for sending this message. If the message was successfully sent,
             then the message will have a nonce with this value.
@@ -1294,10 +1305,10 @@ class Messageable:
             then it is silently ignored.
         allowed_mentions: :class:`~disnake.AllowedMentions`
             Controls the mentions being processed in this message. If this is
-            passed, then the object is merged with :attr:`~disnake.Client.allowed_mentions`.
+            passed, then the object is merged with :attr:`Client.allowed_mentions <disnake.Client.allowed_mentions>`.
             The merging behaviour only overrides attributes that have been explicitly passed
-            to the object, otherwise it uses the attributes set in :attr:`~disnake.Client.allowed_mentions`.
-            If no object is passed at all then the defaults given by :attr:`~disnake.Client.allowed_mentions`
+            to the object, otherwise it uses the attributes set in :attr:`Client.allowed_mentions <disnake.Client.allowed_mentions>`.
+            If no object is passed at all then the defaults given by :attr:`Client.allowed_mentions <disnake.Client.allowed_mentions>`
             are used instead.
 
             .. versionadded:: 1.4
@@ -1316,14 +1327,6 @@ class Messageable:
             .. versionadded:: 1.6
         view: :class:`disnake.ui.View`
             A Discord UI View to add to the message.
-        embeds: List[:class:`~disnake.Embed`]
-            A list of embeds to upload. Must be a maximum of 10.
-
-            .. versionadded:: 2.0
-        stickers: Sequence[Union[:class:`~disnake.GuildSticker`, :class:`~disnake.StickerItem`]]
-            A list of stickers to upload. Must be a maximum of 3.
-
-            .. versionadded:: 2.0
 
         Raises
         --------

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1290,7 +1290,7 @@ class Messageable:
         file: :class:`~disnake.File`
             The file to upload. This cannot be mixed with ``files`` parameter.
         files: List[:class:`~disnake.File`]
-            A list of files to send with the content. Must be a maximum of 10.
+            A list of files to upload. Must be a maximum of 10.
             This cannot be mixed with the ``file`` parameter.
         stickers: Sequence[Union[:class:`~disnake.GuildSticker`, :class:`~disnake.StickerItem`]]
             A list of stickers to upload. Must be a maximum of 3.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -292,6 +292,7 @@ class Interaction:
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
     ) -> InteractionMessage:
@@ -323,6 +324,11 @@ class Interaction:
         files: List[:class:`File`]
             A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message.
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all existing attachments are removed.
+
+            .. versionadded:: 2.1
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
@@ -352,6 +358,7 @@ class Interaction:
             content=content,
             file=file,
             files=files,
+            attachments=attachments,
             embed=embed,
             embeds=embeds,
             view=view,
@@ -972,6 +979,7 @@ class InteractionMessage(Message):
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
     ) -> InteractionMessage:
@@ -997,6 +1005,11 @@ class InteractionMessage(Message):
         files: List[:class:`File`]
             A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message.
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all existing attachments are removed.
+
+            .. versionadded:: 2.1
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
@@ -1026,6 +1039,7 @@ class InteractionMessage(Message):
             embed=embed,
             file=file,
             files=files,
+            attachments=attachments,
             view=view,
             allowed_mentions=allowed_mentions,
         )

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -288,8 +288,8 @@ class Interaction:
         self,
         *,
         content: Optional[str] = MISSING,
-        embeds: List[Embed] = MISSING,
         embed: Optional[Embed] = MISSING,
+        embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
         view: Optional[View] = MISSING,
@@ -297,7 +297,7 @@ class Interaction:
     ) -> InteractionMessage:
         """|coro|
 
-        Edits the original interaction response message.
+        Edits the original, previously sent interaction response message.
 
         This is a lower level interface to :meth:`InteractionMessage.edit` in case
         you do not want to fetch the message and save an HTTP request.
@@ -309,22 +309,27 @@ class Interaction:
         ------------
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
-        embeds: List[:class:`Embed`]
-            A list of embeds to edit the message with.
         embed: Optional[:class:`Embed`]
-            The embed to edit the message with. ``None`` suppresses the embeds.
-            This should not be mixed with the ``embeds`` parameter.
+            The new embed to replace the original with. This cannot be mixed with the
+            ``embeds`` parameter.
+            Could be ``None`` to remove the embed.
+        embeds: List[:class:`Embed`]
+            The new embeds to replace the original with. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
+            To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
+            Files will be appended to the message.
         files: List[:class:`File`]
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
-        allowed_mentions: :class:`AllowedMentions`
-            Controls the mentions being processed in this message.
-            See :meth:`.abc.Messageable.send` for more information.
+            Files will be appended to the message.
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
+            See :meth:`.abc.Messageable.send` for more information.
 
         Raises
         -------
@@ -449,16 +454,17 @@ class Interaction:
         -----------
         content: Optional[:class:`str`]
             The content of the message to send.
-        embeds: List[:class:`Embed`]
-            A list of embeds to send with the content. Maximum of 10. This cannot
-            be mixed with the ``embed`` parameter.
         embed: :class:`Embed`
             The rich embed for the content to send. This cannot be mixed with
             ``embeds`` parameter.
-        file: :class:`~disnake.File`
-            The file to upload.
-        files: List[:class:`~disnake.File`]
+        embeds: List[:class:`Embed`]
+            A list of embeds to send with the content. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
+        file: :class:`File`
+            The file to upload. This cannot be mixed with ``files`` parameter.
+        files: List[:class:`File`]
             A list of files to upload. Must be a maximum of 10.
+            This cannot be mixed with the ``file`` parameter.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
         tts: :class:`bool`
@@ -616,22 +622,23 @@ class InteractionResponse:
         -----------
         content: Optional[:class:`str`]
             The content of the message to send.
-        embeds: List[:class:`Embed`]
-            A list of embeds to send with the content. Maximum of 10. This cannot
-            be mixed with the ``embed`` parameter.
         embed: :class:`Embed`
             The rich embed for the content to send. This cannot be mixed with
             ``embeds`` parameter.
-        file: :class:`~disnake.File`
-            The file to upload.
-        files: List[:class:`~disnake.File`]
-            A list of files to upload. Must be a maximum of 10.
+        embeds: List[:class:`Embed`]
+            A list of embeds to send with the content. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
+        file: :class:`File`
+            The file to upload. This cannot be mixed with ``files`` parameter.
+        files: List[:class:`File`]
+            A list of files to send with the content. Must be a maximum of 10.
+            This cannot be mixed with the ``file`` parameter.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
-        tts: :class:`bool`
-            Indicates if the message should be sent using text-to-speech.
         view: :class:`disnake.ui.View`
             The view to send with the message.
+        tts: :class:`bool`
+            Indicates if the message should be sent using text-to-speech.
         ephemeral: :class:`bool`
             Indicates if the message should only be visible to the user who started the interaction.
             If a view is sent with an ephemeral message and it has no timeout set then the timeout
@@ -743,8 +750,8 @@ class InteractionResponse:
         content: Optional[Any] = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
-        allowed_mentions: AllowedMentions = MISSING,
         attachments: List[Attachment] = MISSING,
+        allowed_mentions: AllowedMentions = MISSING,
         view: Optional[View] = MISSING,
     ) -> None:
         """|coro|
@@ -756,16 +763,19 @@ class InteractionResponse:
         -----------
         content: Optional[:class:`str`]
             The new content to replace the message with. ``None`` removes the content.
-        embeds: List[:class:`Embed`]
-            A list of embeds to edit the message with.
         embed: Optional[:class:`Embed`]
-            The embed to edit the message with. ``None`` suppresses the embeds.
-            This should not be mixed with the ``embeds`` parameter.
-        allowed_mentions: :class:`AllowedMentions`
-            Controls the mentions being processed in this message.
+            The new embed to replace the original with. This cannot be mixed with the
+            ``embeds`` parameter.
+            Could be ``None`` to remove the embed.
+        embeds: List[:class:`Embed`]
+            The new embeds to replace the original with. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
+            To remove all embeds ``[]`` should be passed.
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all attachments are removed.
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
@@ -930,8 +940,8 @@ class InteractionMessage(Message):
     async def edit(
         self,
         content: Optional[str] = MISSING,
-        embeds: List[Embed] = MISSING,
         embed: Optional[Embed] = MISSING,
+        embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
         view: Optional[View] = MISSING,
@@ -945,22 +955,27 @@ class InteractionMessage(Message):
         ------------
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
-        embeds: List[:class:`Embed`]
-            A list of embeds to edit the message with.
         embed: Optional[:class:`Embed`]
-            The embed to edit the message with. ``None`` suppresses the embeds.
-            This should not be mixed with the ``embeds`` parameter.
+            The new embed to replace the original with. This cannot be mixed with the
+            ``embeds`` parameter.
+            Could be ``None`` to remove the embed.
+        embeds: List[:class:`Embed`]
+            The new embeds to replace the original with. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
+            To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
+            Files will be appended to the message.
         files: List[:class:`File`]
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
-        allowed_mentions: :class:`AllowedMentions`
-            Controls the mentions being processed in this message.
-            See :meth:`.abc.Messageable.send` for more information.
+            Files will be appended to the message.
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
+            See :meth:`.abc.Messageable.send` for more information.
 
         Raises
         -------

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -754,6 +754,8 @@ class InteractionResponse:
         content: Optional[Any] = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
+        file: File = MISSING,
+        files: List[File] = MISSING,
         attachments: List[Attachment] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         view: Optional[View] = MISSING,
@@ -775,6 +777,18 @@ class InteractionResponse:
             The new embeds to replace the original with. Must be a maximum of 10.
             This cannot be mixed with the ``embed`` parameter.
             To remove all embeds ``[]`` should be passed.
+        file: :class:`File`
+            The file to upload. This cannot be mixed with ``files`` parameter.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
+
+            .. versionadded:: 2.1
+        files: List[:class:`File`]
+            A list of files to upload. This cannot be mixed with the ``file`` parameter.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
+
+            .. versionadded:: 2.1
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all attachments are removed.
@@ -819,6 +833,15 @@ class InteractionResponse:
                         "Embed images in edit interaction responses are not supported"
                     )
 
+        if file is not MISSING and files is not MISSING:
+            raise TypeError("cannot mix file and files keyword arguments")
+
+        if file is not MISSING:
+            files = [file]
+
+        if files is not MISSING and len(files) > 10:
+            raise ValueError("files cannot exceed maximum of 10 elements")
+
         previous_mentions: Optional[AllowedMentions] = getattr(
             self._parent._state, "allowed_mentions", None
         )
@@ -844,6 +867,7 @@ class InteractionResponse:
             session=parent._session,
             type=InteractionResponseType.message_update.value,
             data=payload,
+            files=files,
         )
 
         if view and not view.is_finished():

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -763,7 +763,7 @@ class InteractionResponse:
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
-        attachments: List[Attachment] = MISSING,
+        # attachments: List[Attachment] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         view: Optional[View] = MISSING,
     ) -> None:
@@ -771,6 +771,13 @@ class InteractionResponse:
 
         Responds to this interaction by editing the original message of
         a component interaction.
+
+        .. note::
+            The ``attachments`` parameter is currently non-functional, removing/replacing existing
+            attachments using this method is presently not supported (API limitation, see
+            `this <https://github.com/discord/discord-api-docs/discussions/3335>`_).
+            As a workaround, respond to the interaction first (e.g. using :meth:`.defer`),
+            then edit the message using :meth:`.edit_original_message`.
 
         Parameters
         -----------
@@ -786,19 +793,14 @@ class InteractionResponse:
             To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
-            Files will be appended to the message, see the ``attachments`` parameter
-            to remove/replace existing files.
+            Files will be appended to the message.
 
             .. versionadded:: 2.1
         files: List[:class:`File`]
             A list of files to upload. This cannot be mixed with the ``file`` parameter.
-            Files will be appended to the message, see the ``attachments`` parameter
-            to remove/replace existing files.
+            Files will be appended to the message.
 
             .. versionadded:: 2.1
-        attachments: List[:class:`Attachment`]
-            A list of attachments to keep in the message. If ``[]`` is passed
-            then all attachments are removed.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
         view: Optional[:class:`~disnake.ui.View`]
@@ -860,8 +862,8 @@ class InteractionResponse:
         elif previous_mentions is not None:
             payload["allowed_mentions"] = previous_mentions.to_dict()
 
-        if attachments is not MISSING:
-            payload["attachments"] = [a.to_dict() for a in attachments]
+        # if attachments is not MISSING:
+        #     payload["attachments"] = [a.to_dict() for a in attachments]
 
         if view is not MISSING:
             if message_id:

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -465,7 +465,12 @@ class Interaction:
             A list of files to upload. Must be a maximum of 10.
             This cannot be mixed with the ``file`` parameter.
         allowed_mentions: :class:`AllowedMentions`
-            Controls the mentions being processed in this message.
+            Controls the mentions being processed in this message. If this is
+            passed, then the object is merged with :attr:`Client.allowed_mentions <disnake.Client.allowed_mentions>`.
+            The merging behaviour only overrides attributes that have been explicitly passed
+            to the object, otherwise it uses the attributes set in :attr:`Client.allowed_mentions <disnake.Client.allowed_mentions>`.
+            If no object is passed at all then the defaults given by :attr:`Client.allowed_mentions <disnake.Client.allowed_mentions>`
+            are used instead.
         tts: :class:`bool`
             Indicates if the message should be sent using text-to-speech.
         view: :class:`disnake.ui.View`

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -321,8 +321,7 @@ class Interaction:
             The file to upload. This cannot be mixed with ``files`` parameter.
             Files will be appended to the message.
         files: List[:class:`File`]
-            A list of files to send with the content. This cannot be mixed with the
-            ``file`` parameter.
+            A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message.
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
@@ -631,7 +630,7 @@ class InteractionResponse:
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
         files: List[:class:`File`]
-            A list of files to send with the content. Must be a maximum of 10.
+            A list of files to upload. Must be a maximum of 10.
             This cannot be mixed with the ``file`` parameter.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
@@ -967,8 +966,7 @@ class InteractionMessage(Message):
             The file to upload. This cannot be mixed with ``files`` parameter.
             Files will be appended to the message.
         files: List[:class:`File`]
-            A list of files to send with the content. This cannot be mixed with the
-            ``file`` parameter.
+            A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message.
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1404,10 +1404,12 @@ class Message(Hashable):
             The new content to replace the message with.
             Could be ``None`` to remove the content.
         embed: Optional[:class:`Embed`]
-            The new embed to replace the original with.
+            The new embed to replace the original with. This cannot be mixed with the
+            ``embeds`` parameter.
             Could be ``None`` to remove the embed.
         embeds: List[:class:`Embed`]
             The new embeds to replace the original with. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
             To remove all embeds ``[]`` should be passed.
 
             .. versionadded:: 2.0
@@ -1911,10 +1913,12 @@ class PartialMessage(Hashable):
             The new content to replace the message with.
             Could be ``None`` to remove the content.
         embed: Optional[:class:`Embed`]
-            The new embed to replace the original with.
+            The new embed to replace the original with. This cannot be mixed with the
+            ``embeds`` parameter.
             Could be ``None`` to remove the embed.
         embeds: List[:class:`Embed`]
             The new embeds to replace the original with. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
             To remove all embeds ``[]`` should be passed.
 
             .. versionadded:: 2.1

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1420,8 +1420,7 @@ class Message(Hashable):
 
             .. versionadded:: 2.1
         files: List[:class:`File`]
-            A list of files to send with the content. This cannot be mixed with the
-            ``file`` parameter.
+            A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message, see the ``attachments`` parameter
             to remove/replace existing files.
 
@@ -1929,8 +1928,7 @@ class PartialMessage(Hashable):
 
             .. versionadded:: 2.1
         files: List[:class:`File`]
-            A list of files to send with the content. This cannot be mixed with the
-            ``file`` parameter.
+            A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message, see the ``attachments`` parameter
             to remove/replace existing files.
 

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -67,6 +67,7 @@ _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ..file import File
+    from ..message import Attachment
     from ..embeds import Embed
     from ..mentions import AllowedMentions
     from ..state import ConnectionState
@@ -475,6 +476,7 @@ def handle_message_parameters(
     ephemeral: bool = False,
     file: File = MISSING,
     files: List[File] = MISSING,
+    attachments: List[Attachment] = MISSING,
     embed: Optional[Embed] = MISSING,
     embeds: List[Embed] = MISSING,
     view: Optional[View] = MISSING,
@@ -505,6 +507,10 @@ def handle_message_parameters(
         payload["content"] = str(content) if content is not None else None
     if view is not MISSING:
         payload["components"] = view.to_components() if view is not None else []
+
+    if attachments is not MISSING:
+        payload["attachments"] = [a.to_dict() for a in attachments]
+
     payload["tts"] = tts
     if avatar_url:
         payload["avatar_url"] = str(avatar_url)
@@ -667,6 +673,7 @@ class WebhookMessage(Message):
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
     ) -> WebhookMessage:
@@ -701,6 +708,11 @@ class WebhookMessage(Message):
             Files will be appended to the message.
 
             .. versionadded:: 2.0
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all existing attachments are removed.
+
+            .. versionadded:: 2.1
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
@@ -735,6 +747,7 @@ class WebhookMessage(Message):
             embed=embed,
             file=file,
             files=files,
+            attachments=attachments,
             view=view,
             allowed_mentions=allowed_mentions,
         )
@@ -1535,6 +1548,7 @@ class Webhook(BaseWebhook):
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
     ) -> WebhookMessage:
@@ -1575,6 +1589,11 @@ class Webhook(BaseWebhook):
             Files will be appended to the message.
 
             .. versionadded:: 2.0
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all existing attachments are removed.
+
+            .. versionadded:: 2.1
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed. The webhook must have state attached, similar to
@@ -1621,6 +1640,7 @@ class Webhook(BaseWebhook):
             content=content,
             file=file,
             files=files,
+            attachments=attachments,
             embed=embed,
             embeds=embeds,
             view=view,

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -697,8 +697,7 @@ class WebhookMessage(Message):
 
             .. versionadded:: 2.0
         files: List[:class:`File`]
-            A list of files to send with the content. This cannot be mixed with the
-            ``file`` parameter.
+            A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message.
 
             .. versionadded:: 2.0
@@ -1355,7 +1354,7 @@ class Webhook(BaseWebhook):
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
         files: List[:class:`File`]
-            A list of files to send with the content. Must be a maximum of 10.
+            A list of files to upload. Must be a maximum of 10.
             This cannot be mixed with the ``file`` parameter.
         embed: :class:`Embed`
             The rich embed for the content to send. This cannot be mixed with

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -663,8 +663,8 @@ class WebhookMessage(Message):
     async def edit(
         self,
         content: Optional[str] = MISSING,
-        embeds: List[Embed] = MISSING,
         embed: Optional[Embed] = MISSING,
+        embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
         view: Optional[View] = MISSING,
@@ -683,28 +683,33 @@ class WebhookMessage(Message):
         ------------
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
-        embeds: List[:class:`Embed`]
-            A list of embeds to edit the message with.
         embed: Optional[:class:`Embed`]
-            The embed to edit the message with. ``None`` suppresses the embeds.
-            This should not be mixed with the ``embeds`` parameter.
+            The new embed to replace the original with. This cannot be mixed with the
+            ``embeds`` parameter.
+            Could be ``None`` to remove the embed.
+        embeds: List[:class:`Embed`]
+            The new embeds to replace the original with. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
+            To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
+            Files will be appended to the message.
 
             .. versionadded:: 2.0
         files: List[:class:`File`]
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
+            Files will be appended to the message.
 
             .. versionadded:: 2.0
-        allowed_mentions: :class:`AllowedMentions`
-            Controls the mentions being processed in this message.
-            See :meth:`.abc.Messageable.send` for more information.
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
 
             .. versionadded:: 2.0
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
+            See :meth:`.abc.Messageable.send` for more information.
 
         Raises
         -------
@@ -1331,11 +1336,6 @@ class Webhook(BaseWebhook):
         ------------
         content: :class:`str`
             The content of the message to send.
-        wait: :class:`bool`
-            Whether the server should wait before sending a response. This essentially
-            means that the return type of this function changes from ``None`` to
-            a :class:`WebhookMessage` if set to ``True``. If the type of webhook
-            is :attr:`WebhookType.application` then this is always set to ``True``.
         username: :class:`str`
             The username to send with this message. If no username is provided
             then the default username for the webhook is used.
@@ -1355,14 +1355,14 @@ class Webhook(BaseWebhook):
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
         files: List[:class:`File`]
-            A list of files to send with the content. This cannot be mixed with the
-            ``file`` parameter.
+            A list of files to send with the content. Must be a maximum of 10.
+            This cannot be mixed with the ``file`` parameter.
         embed: :class:`Embed`
             The rich embed for the content to send. This cannot be mixed with
             ``embeds`` parameter.
         embeds: List[:class:`Embed`]
-            A list of embeds to send with the content. Maximum of 10. This cannot
-            be mixed with the ``embed`` parameter.
+            A list of embeds to send with the content. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
 
@@ -1378,7 +1378,11 @@ class Webhook(BaseWebhook):
             The thread to send this webhook to.
 
             .. versionadded:: 2.0
-
+        wait: :class:`bool`
+            Whether the server should wait before sending a response. This essentially
+            means that the return type of this function changes from ``None`` to
+            a :class:`WebhookMessage` if set to ``True``. If the type of webhook
+            is :attr:`WebhookType.application` then this is always set to ``True``.
         delete_after: :class:`float`
             If provided, the number of seconds to wait in the background
             before deleting the message we just sent. If the deletion fails,
@@ -1522,8 +1526,8 @@ class Webhook(BaseWebhook):
         message_id: int,
         *,
         content: Optional[str] = MISSING,
-        embeds: List[Embed] = MISSING,
         embed: Optional[Embed] = MISSING,
+        embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
         view: Optional[View] = MISSING,
@@ -1547,29 +1551,34 @@ class Webhook(BaseWebhook):
             The message ID to edit.
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
-        embeds: List[:class:`Embed`]
-            A list of embeds to edit the message with.
         embed: Optional[:class:`Embed`]
-            The embed to edit the message with. ``None`` suppresses the embeds.
-            This should not be mixed with the ``embeds`` parameter.
+            The new embed to replace the original with. This cannot be mixed with the
+            ``embeds`` parameter.
+            Could be ``None`` to remove the embed.
+        embeds: List[:class:`Embed`]
+            The new embeds to replace the original with. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
+            To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
+            Files will be appended to the message.
 
             .. versionadded:: 2.0
         files: List[:class:`File`]
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
+            Files will be appended to the message.
 
             .. versionadded:: 2.0
-        allowed_mentions: :class:`AllowedMentions`
-            Controls the mentions being processed in this message.
-            See :meth:`.abc.Messageable.send` for more information.
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed. The webhook must have state attached, similar to
             :meth:`send`.
 
             .. versionadded:: 2.0
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
+            See :meth:`.abc.Messageable.send` for more information.
 
         Raises
         -------

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1363,7 +1363,13 @@ class Webhook(BaseWebhook):
             A list of embeds to send with the content. Must be a maximum of 10.
             This cannot be mixed with the ``embed`` parameter.
         allowed_mentions: :class:`AllowedMentions`
-            Controls the mentions being processed in this message.
+            Controls the mentions being processed in this message. If this is
+            passed, then the object is merged with :attr:`Client.allowed_mentions <disnake.Client.allowed_mentions>`,
+            if applicable.
+            The merging behaviour only overrides attributes that have been explicitly passed
+            to the object, otherwise it uses the attributes set in :attr:`Client.allowed_mentions <disnake.Client.allowed_mentions>`.
+            If no object is passed at all then the defaults given by :attr:`Client.allowed_mentions <disnake.Client.allowed_mentions>`
+            are used instead.
 
             .. versionadded:: 1.4
         view: :class:`disnake.ui.View`

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -68,6 +68,7 @@ _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ..file import File
+    from ..message import Attachment
     from ..embeds import Embed
     from ..mentions import AllowedMentions
     from ..types.webhook import (
@@ -422,6 +423,7 @@ class SyncWebhookMessage(Message):
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
     ) -> SyncWebhookMessage:
         """Edits the message.
@@ -444,6 +446,11 @@ class SyncWebhookMessage(Message):
         files: List[:class:`File`]
             A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message.
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all existing attachments are removed.
+
+            .. versionadded:: 2.1
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
@@ -473,6 +480,7 @@ class SyncWebhookMessage(Message):
             embed=embed,
             file=file,
             files=files,
+            attachments=attachments,
             allowed_mentions=allowed_mentions,
         )
 
@@ -1034,6 +1042,7 @@ class SyncWebhook(BaseWebhook):
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
     ) -> SyncWebhookMessage:
         """Edits a message owned by this webhook.
@@ -1063,6 +1072,11 @@ class SyncWebhook(BaseWebhook):
         files: List[:class:`File`]
             A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message.
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all existing attachments are removed.
+
+            .. versionadded:: 2.1
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
@@ -1091,6 +1105,7 @@ class SyncWebhook(BaseWebhook):
             content=content,
             file=file,
             files=files,
+            attachments=attachments,
             embed=embed,
             embeds=embeds,
             allowed_mentions=allowed_mentions,

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -418,8 +418,8 @@ class SyncWebhookMessage(Message):
     def edit(
         self,
         content: Optional[str] = MISSING,
-        embeds: List[Embed] = MISSING,
         embed: Optional[Embed] = MISSING,
+        embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
@@ -430,16 +430,21 @@ class SyncWebhookMessage(Message):
         ------------
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
-        embeds: List[:class:`Embed`]
-            A list of embeds to edit the message with.
         embed: Optional[:class:`Embed`]
-            The embed to edit the message with. ``None`` suppresses the embeds.
-            This should not be mixed with the ``embeds`` parameter.
+            The new embed to replace the original with. This cannot be mixed with the
+            ``embeds`` parameter.
+            Could be ``None`` to remove the embed.
+        embeds: List[:class:`Embed`]
+            The new embeds to replace the original with. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
+            To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
+            Files will be appended to the message.
         files: List[:class:`File`]
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
+            Files will be appended to the message.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
@@ -889,10 +894,6 @@ class SyncWebhook(BaseWebhook):
         ------------
         content: :class:`str`
             The content of the message to send.
-        wait: :class:`bool`
-            Whether the server should wait before sending a response. This essentially
-            means that the return type of this function changes from ``None`` to
-            a :class:`WebhookMessage` if set to ``True``.
         username: :class:`str`
             The username to send with this message. If no username is provided
             then the default username for the webhook is used.
@@ -905,14 +906,14 @@ class SyncWebhook(BaseWebhook):
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
         files: List[:class:`File`]
-            A list of files to send with the content. This cannot be mixed with the
-            ``file`` parameter.
+            A list of files to send with the content. Must be a maximum of 10.
+            This cannot be mixed with the ``file`` parameter.
         embed: :class:`Embed`
             The rich embed for the content to send. This cannot be mixed with
             ``embeds`` parameter.
         embeds: List[:class:`Embed`]
-            A list of embeds to send with the content. Maximum of 10. This cannot
-            be mixed with the ``embed`` parameter.
+            A list of embeds to send with the content. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
 
@@ -921,6 +922,10 @@ class SyncWebhook(BaseWebhook):
             The thread to send this message to.
 
             .. versionadded:: 2.0
+        wait: :class:`bool`
+            Whether the server should wait before sending a response. This essentially
+            means that the return type of this function changes from ``None`` to
+            a :class:`WebhookMessage` if set to ``True``.
 
         Raises
         --------
@@ -1026,8 +1031,8 @@ class SyncWebhook(BaseWebhook):
         message_id: int,
         *,
         content: Optional[str] = MISSING,
-        embeds: List[Embed] = MISSING,
         embed: Optional[Embed] = MISSING,
+        embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
@@ -1045,16 +1050,21 @@ class SyncWebhook(BaseWebhook):
             The message ID to edit.
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
-        embeds: List[:class:`Embed`]
-            A list of embeds to edit the message with.
         embed: Optional[:class:`Embed`]
-            The embed to edit the message with. ``None`` suppresses the embeds.
-            This should not be mixed with the ``embeds`` parameter.
+            The new embed to replace the original with. This cannot be mixed with the
+            ``embeds`` parameter.
+            Could be ``None`` to remove the embed.
+        embeds: List[:class:`Embed`]
+            The new embeds to replace the original with. Must be a maximum of 10.
+            This cannot be mixed with the ``embed`` parameter.
+            To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
+            Files will be appended to the message.
         files: List[:class:`File`]
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
+            Files will be appended to the message.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -442,8 +442,7 @@ class SyncWebhookMessage(Message):
             The file to upload. This cannot be mixed with ``files`` parameter.
             Files will be appended to the message.
         files: List[:class:`File`]
-            A list of files to send with the content. This cannot be mixed with the
-            ``file`` parameter.
+            A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
@@ -906,7 +905,7 @@ class SyncWebhook(BaseWebhook):
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
         files: List[:class:`File`]
-            A list of files to send with the content. Must be a maximum of 10.
+            A list of files to upload. Must be a maximum of 10.
             This cannot be mixed with the ``file`` parameter.
         embed: :class:`Embed`
             The rich embed for the content to send. This cannot be mixed with
@@ -1062,8 +1061,7 @@ class SyncWebhook(BaseWebhook):
             The file to upload. This cannot be mixed with ``files`` parameter.
             Files will be appended to the message.
         files: List[:class:`File`]
-            A list of files to send with the content. This cannot be mixed with the
-            ``file`` parameter.
+            A list of files to upload. This cannot be mixed with the ``file`` parameter.
             Files will be appended to the message.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.


### PR DESCRIPTION
## Summary

- Updated descriptions of `file`/`files` and `embed`/`embeds` parameters to match in the entire project, also changing the order a bit to match the parameter specifications
- Added support for the `attachments` parameter in most places, which allows removing existing attachments on edit and was missing previously
- Added support for files to `inter.response.edit_message`, and removed the `attachments` parameter on it for now (see docstring for details)

Kind of but not really a breaking change, since the `attachments` parameter got removed; it wasn't working anyway.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
