### PR TITLE
Add attachment descriptions

### DIFF
--- a/disnake/file.py
+++ b/disnake/file.py
@@ -63,7 +63,7 @@ class File:
     description: Optional[:class:`str`]
         The file's description.
 
-        .. versionadded:: 2.1
+        .. versionadded:: 2.3
     """
 
     __slots__ = ("fp", "filename", "spoiler", "description", "_original_pos", "_owner", "_closer")

--- a/disnake/file.py
+++ b/disnake/file.py
@@ -60,14 +60,19 @@ class File:
         a string then the ``filename`` will default to the string given.
     spoiler: :class:`bool`
         Whether the attachment is a spoiler.
+    description: Optional[:class:`str`]
+        The file's description.
+
+        .. versionadded:: 2.1
     """
 
-    __slots__ = ("fp", "filename", "spoiler", "_original_pos", "_owner", "_closer")
+    __slots__ = ("fp", "filename", "spoiler", "description", "_original_pos", "_owner", "_closer")
 
     if TYPE_CHECKING:
         fp: io.BufferedIOBase
         filename: Optional[str]
         spoiler: bool
+        description: Optional[str]
 
     def __init__(
         self,
@@ -75,6 +80,7 @@ class File:
         filename: Optional[str] = None,
         *,
         spoiler: bool = False,
+        description: Optional[str] = None,
     ):
         if isinstance(fp, io.IOBase):
             if not (fp.seekable() and fp.readable()):
@@ -108,6 +114,7 @@ class File:
         self.spoiler = spoiler or (
             self.filename is not None and self.filename.startswith("SPOILER_")
         )
+        self.description = description
 
     def reset(self, *, seek: Union[int, bool] = True) -> None:
         # The `seek` parameter is needed because

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -305,9 +305,12 @@ class HTTPClient:
                         f.reset(seek=tries)
 
                 if form:
-                    form_data = aiohttp.FormData()
+                    # NOTE: for `quote_fields`, see https://github.com/aio-libs/aiohttp/issues/4012
+                    form_data = aiohttp.FormData(quote_fields=False)
                     for params in form:
-                        form_data.add_field(**params)
+                        # manually escape double quotes and backslashes, like urllib3
+                        name = params.pop("name").replace('"', "%22").replace("\\", "\\\\")
+                        form_data.add_field(name=name, **params)
                     kwargs["data"] = form_data
 
                 try:

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -65,6 +65,7 @@ _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .file import File
+    from .message import Attachment
     from .enums import (
         AuditLogAction,
         InteractionResponseType,
@@ -1999,7 +2000,11 @@ class HTTPClient:
         content: Optional[str] = None,
         embeds: Optional[List[embed.Embed]] = None,
         allowed_mentions: Optional[message.AllowedMentions] = None,
+        attachments: Optional[List[Attachment]] = None,
     ):
+        # TODO: this does not work how it should (e.g. `embeds=[]` is ignored).
+        #       This method (or rather its calling methods) is completely unused, and hence likely untested
+
         payload: Dict[str, Any] = {}
         if content:
             payload["content"] = content
@@ -2007,6 +2012,8 @@ class HTTPClient:
             payload["embeds"] = embeds
         if allowed_mentions:
             payload["allowed_mentions"] = allowed_mentions
+        if attachments:
+            payload["attachments"] = attachments
 
         if file:
             multipart = to_multipart(payload, [file])
@@ -2057,6 +2064,7 @@ class HTTPClient:
         content: Optional[str] = None,
         embeds: Optional[List[embed.Embed]] = None,
         allowed_mentions: Optional[message.AllowedMentions] = None,
+        attachments: Optional[List[Attachment]] = None,
     ) -> Response[message.Message]:
         r = Route(
             "PATCH",
@@ -2065,7 +2073,12 @@ class HTTPClient:
             interaction_token=token,
         )
         return self._edit_webhook_helper(
-            r, file=file, content=content, embeds=embeds, allowed_mentions=allowed_mentions
+            r,
+            file=file,
+            content=content,
+            embeds=embeds,
+            allowed_mentions=allowed_mentions,
+            attachments=attachments,
         )
 
     def delete_original_interaction_response(
@@ -2113,6 +2126,7 @@ class HTTPClient:
         content: Optional[str] = None,
         embeds: Optional[List[embed.Embed]] = None,
         allowed_mentions: Optional[message.AllowedMentions] = None,
+        attachments: Optional[List[Attachment]] = None,
     ) -> Response[message.Message]:
         r = Route(
             "PATCH",
@@ -2122,7 +2136,12 @@ class HTTPClient:
             message_id=message_id,
         )
         return self._edit_webhook_helper(
-            r, file=file, content=content, embeds=embeds, allowed_mentions=allowed_mentions
+            r,
+            file=file,
+            content=content,
+            embeds=embeds,
+            allowed_mentions=allowed_mentions,
+            attachments=attachments,
         )
 
     def delete_followup_message(

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -320,13 +320,16 @@ class Interaction:
             To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
         files: List[:class:`File`]
             A list of files to upload. This cannot be mixed with the ``file`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all existing attachments are removed.
+            Keeps existing attachments if not provided.
 
             .. versionadded:: 2.1
         view: Optional[:class:`~disnake.ui.View`]
@@ -352,6 +355,11 @@ class Interaction:
         :class:`InteractionMessage`
             The newly edited message.
         """
+
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        if attachments is MISSING and (file or files):
+            attachments = (await self.original_message()).attachments
 
         previous_mentions: Optional[AllowedMentions] = self._state.allowed_mentions
         params = handle_message_parameters(
@@ -869,6 +877,7 @@ class InteractionResponse:
             if message_id:
                 state.prevent_view_updates_for(message_id)
             payload["components"] = [] if view is None else view.to_components()
+
         adapter = async_context.get()
         await adapter.create_interaction_response(
             parent.id,
@@ -1010,6 +1019,7 @@ class InteractionMessage(Message):
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all existing attachments are removed.
+            Keeps existing attachments if not provided.
 
             .. versionadded:: 2.1
         view: Optional[:class:`~disnake.ui.View`]
@@ -1035,6 +1045,12 @@ class InteractionMessage(Message):
         :class:`InteractionMessage`
             The newly edited message.
         """
+
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        if attachments is MISSING and (file or files):
+            attachments = self.attachments
+
         return await self._state._interaction.edit_original_message(
             content=content,
             embeds=embeds,

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1030,10 +1030,12 @@ class InteractionMessage(Message):
             To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
         files: List[:class:`File`]
             A list of files to upload. This cannot be mixed with the ``file`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all existing attachments are removed.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -306,6 +306,12 @@ class Interaction:
         This method is also the only way to edit the original message if
         the message sent was ephemeral.
 
+        .. note::
+            If the original message has embeds with images that were created from local files
+            (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
+            those images will be removed if the message's attachments are edited in any way
+            (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
+
         Parameters
         ------------
         content: Optional[:class:`str`]
@@ -787,6 +793,12 @@ class InteractionResponse:
             As a workaround, respond to the interaction first (e.g. using :meth:`.defer`),
             then edit the message using :meth:`.edit_original_message`.
 
+        .. note::
+            If the original message has embeds with images that were created from local files
+            (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
+            those images will be removed if the message's attachments are edited in any way
+            (i.e. by setting ``file``/``files``, or adding an embed with local files).
+
         Parameters
         -----------
         content: Optional[:class:`str`]
@@ -997,6 +1009,12 @@ class InteractionMessage(Message):
         """|coro|
 
         Edits the message.
+
+        .. note::
+            If the original message has embeds with images that were created from local files
+            (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
+            those images will be removed if the message's attachments are edited in any way
+            (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
 
         Parameters
         ------------

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -125,8 +125,8 @@ def convert_emoji_reaction(emoji):
 async def _edit_handler(
     msg: Union[Message, PartialMessage],
     *,
-    default_allowed_mentions: Optional[AllowedMentions],
     default_flags: int,
+    previous_allowed_mentions: Optional[AllowedMentions],
     content: Optional[str] = MISSING,
     embed: Optional[Embed] = MISSING,
     embeds: List[Embed] = MISSING,
@@ -168,8 +168,8 @@ async def _edit_handler(
         payload["flags"] = flags.value
 
     if allowed_mentions is MISSING:
-        if default_allowed_mentions:
-            payload["allowed_mentions"] = default_allowed_mentions.to_dict()
+        if previous_allowed_mentions:
+            payload["allowed_mentions"] = previous_allowed_mentions.to_dict()
     else:
         if allowed_mentions:
             if msg._state.allowed_mentions is not None:
@@ -1493,14 +1493,14 @@ class Message(Hashable):
 
         # allowed_mentions can only be changed on the bot's own messages
         if self._state.allowed_mentions is not None and self.author.id == self._state.self_id:
-            default_allowed_mentions = self._state.allowed_mentions
+            previous_allowed_mentions = self._state.allowed_mentions
         else:
-            default_allowed_mentions = None
+            previous_allowed_mentions = None
 
         return await _edit_handler(
             self,
-            default_allowed_mentions=default_allowed_mentions,
             default_flags=self.flags.value,
+            previous_allowed_mentions=previous_allowed_mentions,
             **fields,
         )
 
@@ -2007,7 +2007,7 @@ class PartialMessage(Hashable):
 
         return await _edit_handler(
             self,
-            default_allowed_mentions=None,
             default_flags=0,
+            previous_allowed_mentions=None,
             **fields,
         )

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1453,6 +1453,7 @@ class Message(Hashable):
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all existing attachments are removed.
+            Keeps existing attachments if not provided.
         suppress: :class:`bool`
             Whether to suppress embeds for the message. This removes
             all the embeds if set to ``True``. If set to ``False``
@@ -1496,6 +1497,11 @@ class Message(Hashable):
             previous_allowed_mentions = self._state.allowed_mentions
         else:
             previous_allowed_mentions = None
+
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        if "attachments" not in fields and (fields.get("file") or fields.get("files")):
+            fields["attachments"] = self.attachments
 
         return await _edit_handler(
             self,
@@ -1961,6 +1967,7 @@ class PartialMessage(Hashable):
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all existing attachments are removed.
+            Keeps existing attachments if not provided.
 
             .. versionadded:: 2.1
         suppress: :class:`bool`
@@ -2004,6 +2011,11 @@ class PartialMessage(Hashable):
         :class:`Message`
             The message that was edited.
         """
+
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        if "attachments" not in fields and (fields.get("file") or fields.get("files")):
+            fields["attachments"] = (await self.fetch()).attachments
 
         return await _edit_handler(
             self,

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -255,7 +255,7 @@ class Attachment(Hashable):
     description: :class:`str`
         The attachment's description
 
-        .. versionadded:: 2.1
+        .. versionadded:: 2.3
     """
 
     __slots__ = (
@@ -412,6 +412,8 @@ class Attachment(Hashable):
         description: Optional[:class:`str`]
             The file's description. Copies this attachment's description by default,
             set to ``None`` to remove.
+
+            .. versionadded:: 2.3
 
         Raises
         ------

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1425,6 +1425,12 @@ class Message(Hashable):
         .. versionchanged:: 1.3
             The ``suppress`` keyword-only parameter was added.
 
+        .. note::
+            If the original message has embeds with images that were created from local files
+            (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
+            those images will be removed if the message's attachments are edited in any way
+            (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
+
         Parameters
         -----------
         content: Optional[:class:`str`]
@@ -1938,6 +1944,12 @@ class PartialMessage(Hashable):
 
         .. versionchanged:: 2.1
             :class:`disnake.Message` is always returned.
+
+        .. note::
+            If the original message has embeds with images that were created from local files
+            (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
+            those images will be removed if the message's attachments are edited in any way
+            (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
 
         Parameters
         -----------

--- a/disnake/types/message.py
+++ b/disnake/types/message.py
@@ -53,7 +53,8 @@ class _AttachmentOptional(TypedDict, total=False):
     height: Optional[int]
     width: Optional[int]
     content_type: str
-    spoiler: bool
+    ephemeral: bool
+    description: str
 
 
 class Attachment(_AttachmentOptional):

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -153,9 +153,12 @@ class AsyncWebhookAdapter:
                     file.reset(seek=attempt)
 
                 if multipart:
-                    form_data = aiohttp.FormData()
+                    # NOTE: for `quote_fields`, see https://github.com/aio-libs/aiohttp/issues/4012
+                    form_data = aiohttp.FormData(quote_fields=False)
                     for p in multipart:
-                        form_data.add_field(**p)
+                        # manually escape double quotes and backslashes, like urllib3
+                        name = p.pop("name").replace('"', "%22").replace("\\", "\\\\")
+                        form_data.add_field(name=name, **p)
                     to_send = form_data
 
                 try:

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1583,18 +1583,20 @@ class Webhook(BaseWebhook):
             To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
 
             .. versionadded:: 2.0
         files: List[:class:`File`]
-            A list of files to send with the content. This cannot be mixed with the
-            ``file`` parameter.
-            Files will be appended to the message.
+            A list of files to upload. This cannot be mixed with the ``file`` parameter.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
 
             .. versionadded:: 2.0
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all existing attachments are removed.
+            Keeps existing attachments if not provided.
 
             .. versionadded:: 2.1
         view: Optional[:class:`~disnake.ui.View`]
@@ -1635,6 +1637,11 @@ class Webhook(BaseWebhook):
                 raise InvalidArgument("This webhook does not have state associated with it")
 
             self._state.prevent_view_updates_for(message_id)
+
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        if attachments is MISSING and (file or files):
+            attachments = (await self.fetch_message(message_id)).attachments
 
         previous_mentions: Optional[AllowedMentions] = getattr(
             self._state, "allowed_mentions", None

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -703,17 +703,20 @@ class WebhookMessage(Message):
             To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
 
             .. versionadded:: 2.0
         files: List[:class:`File`]
             A list of files to upload. This cannot be mixed with the ``file`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
 
             .. versionadded:: 2.0
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all existing attachments are removed.
+            Keeps existing attachments if not provided.
 
             .. versionadded:: 2.1
         view: Optional[:class:`~disnake.ui.View`]

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -752,6 +752,12 @@ class WebhookMessage(Message):
         :class:`WebhookMessage`
             The newly edited message.
         """
+
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        if attachments is MISSING and (file or files):
+            attachments = self.attachments
+
         return await self._state._webhook.edit_message(
             self.id,
             content=content,

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -689,6 +689,12 @@ class WebhookMessage(Message):
         .. versionchanged:: 2.0
             The edit is no longer in-place, instead the newly edited message is returned.
 
+        .. note::
+            If the original message has embeds with images that were created from local files
+            (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
+            those images will be removed if the message's attachments are edited in any way
+            (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
+
         Parameters
         ------------
         content: Optional[:class:`str`]
@@ -1569,6 +1575,12 @@ class Webhook(BaseWebhook):
 
         .. versionchanged:: 2.0
             The edit is no longer in-place, instead the newly edited message is returned.
+
+        .. note::
+            If the original message has embeds with images that were created from local files
+            (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
+            those images will be removed if the message's attachments are edited in any way
+            (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
 
         Parameters
         ------------

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -1068,13 +1068,16 @@ class SyncWebhook(BaseWebhook):
             To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
         files: List[:class:`File`]
             A list of files to upload. This cannot be mixed with the ``file`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all existing attachments are removed.
+            Keeps existing attachments if not provided.
 
             .. versionadded:: 2.1
         allowed_mentions: :class:`AllowedMentions`
@@ -1097,6 +1100,11 @@ class SyncWebhook(BaseWebhook):
 
         if self.token is None:
             raise InvalidArgument("This webhook does not have a token associated with it")
+
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        if attachments is MISSING and (file or files):
+            attachments = self.fetch_message(message_id).attachments
 
         previous_mentions: Optional[AllowedMentions] = getattr(
             self._state, "allowed_mentions", None

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -428,6 +428,12 @@ class SyncWebhookMessage(Message):
     ) -> SyncWebhookMessage:
         """Edits the message.
 
+        .. note::
+            If the original message has embeds with images that were created from local files
+            (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
+            those images will be removed if the message's attachments are edited in any way
+            (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
+
         Parameters
         ------------
         content: Optional[:class:`str`]
@@ -1054,6 +1060,12 @@ class SyncWebhook(BaseWebhook):
         you only have an ID.
 
         .. versionadded:: 1.6
+
+        .. note::
+            If the original message has embeds with images that were created from local files
+            (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
+            those images will be removed if the message's attachments are edited in any way
+            (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
 
         Parameters
         ------------

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -442,13 +442,16 @@ class SyncWebhookMessage(Message):
             To remove all embeds ``[]`` should be passed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
         files: List[:class:`File`]
             A list of files to upload. This cannot be mixed with the ``file`` parameter.
-            Files will be appended to the message.
+            Files will be appended to the message, see the ``attachments`` parameter
+            to remove/replace existing files.
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all existing attachments are removed.
+            Keeps existing attachments if not provided.
 
             .. versionadded:: 2.1
         allowed_mentions: :class:`AllowedMentions`

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -482,6 +482,12 @@ class SyncWebhookMessage(Message):
         :class:`SyncWebhookMessage`
             The newly edited message.
         """
+
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        if attachments is MISSING and (file or files):
+            attachments = self.attachments
+
         return self._state._webhook.edit_message(
             self.id,
             content=content,


### PR DESCRIPTION
## Summary

This implements attachment descriptions; they are already available, but gated behind an experiment in clients (`2021-09_inline_attachment_uploads`).

There is a change in the attachment handling, which would've generally resulted in previous attachments not being kept by default on edit anymore, *if* new files are also being uploaded.
This would affect types that don't contain information about existing attachments, i.e. all types except `Message` and `InteractionMessage`.
To fix this, the original message will be fetched for those types and existing attachments will carry over from that, if new files are being added and the developer didn't explicitly provide the `attachments` kwarg.

Providing existing *and* new attachments in the `attachments` list like this when new files are being uploaded will be required for API v10 at the latest. API v8 itself doesn't require it yet, however it is already needed when using attachment descriptions.

### TODO
- ~~[ ] Check if `attachment://` filenames in embeds keep working as intended~~

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
